### PR TITLE
Update Xdebug to version 2.9.8

### DIFF
--- a/php-74-apache-xdebug-29/Dockerfile
+++ b/php-74-apache-xdebug-29/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-apache
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-2.9.1
+RUN pecl install xdebug-2.9.8
 RUN docker-php-ext-enable xdebug
 RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-74-cli-xdebug-29/Dockerfile
+++ b/php-74-cli-xdebug-29/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4
 # Install PECL extensions
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-2.9.1
+RUN pecl install xdebug-2.9.8
 RUN docker-php-ext-enable xdebug


### PR DESCRIPTION
As per title, this PR updates the bundled version of Xdebug to `2.9.8` for the PHP 7.4 Docker image