### PR TITLE
Add missing PHP Docker images and update Xdebug to version 3 where supported

### DIFF
--- a/php-72-apache-xdebug-29/Dockerfile
+++ b/php-72-apache-xdebug-29/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:7.2-apache
+RUN docker-php-ext-install mysqli
+RUN pecl install xdebug-2.9.8
+RUN docker-php-ext-enable xdebug
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-72-apache-xdebug-30/Dockerfile
+++ b/php-72-apache-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
-FROM php:7.4-apache
+FROM php:7.2-apache
 RUN docker-php-ext-install mysqli
 RUN pecl install xdebug-3.0.0
 RUN docker-php-ext-enable xdebug
-RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-72-apache-xdebug-30/Dockerfile
+++ b/php-72-apache-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.2-apache
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug
 RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-72-cli-xdebug-29/Dockerfile
+++ b/php-72-cli-xdebug-29/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.2
+RUN docker-php-ext-install mysqli
+RUN pecl install xdebug-2.9.8
+RUN docker-php-ext-enable xdebug

--- a/php-72-cli-xdebug-30/Dockerfile
+++ b/php-72-cli-xdebug-30/Dockerfile
@@ -1,5 +1,4 @@
-FROM php:7.4
-# Install PECL extensions
+FROM php:7.2
 RUN docker-php-ext-install mysqli
 RUN pecl install xdebug-3.0.0
 RUN docker-php-ext-enable xdebug

--- a/php-72-cli-xdebug-30/Dockerfile
+++ b/php-72-cli-xdebug-30/Dockerfile
@@ -1,4 +1,4 @@
 FROM php:7.2
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug

--- a/php-73-apache-xdebug-29/Dockerfile
+++ b/php-73-apache-xdebug-29/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:7.3-apache
+RUN docker-php-ext-install mysqli
+RUN pecl install xdebug-2.9.8
+RUN docker-php-ext-enable xdebug
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-73-apache-xdebug-30/Dockerfile
+++ b/php-73-apache-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
-FROM php:7.4-apache
+FROM php:7.3-apache
 RUN docker-php-ext-install mysqli
 RUN pecl install xdebug-3.0.0
 RUN docker-php-ext-enable xdebug
-RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-73-apache-xdebug-30/Dockerfile
+++ b/php-73-apache-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.3-apache
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug
 RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini

--- a/php-73-cli-xdebug-29/Dockerfile
+++ b/php-73-cli-xdebug-29/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.3
+RUN docker-php-ext-install mysqli
+RUN pecl install xdebug-2.9.8
+RUN docker-php-ext-enable xdebug

--- a/php-73-cli-xdebug-30/Dockerfile
+++ b/php-73-cli-xdebug-30/Dockerfile
@@ -1,4 +1,4 @@
 FROM php:7.3
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug

--- a/php-73-cli-xdebug-30/Dockerfile
+++ b/php-73-cli-xdebug-30/Dockerfile
@@ -1,5 +1,4 @@
-FROM php:7.4
-# Install PECL extensions
+FROM php:7.3
 RUN docker-php-ext-install mysqli
 RUN pecl install xdebug-3.0.0
 RUN docker-php-ext-enable xdebug

--- a/php-74-apache-xdebug-30/Dockerfile
+++ b/php-74-apache-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-apache
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/php.ini

--- a/php-74-cli-xdebug-30/Dockerfile
+++ b/php-74-cli-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4
 # Install PECL extensions
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug

--- a/php-80-apache-xdebug-30/Dockerfile
+++ b/php-80-apache-xdebug-30/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:8.0-apache
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/php.ini

--- a/php-80-apache-xdebug-30/Dockerfile
+++ b/php-80-apache-xdebug-30/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.0-apache
 RUN docker-php-ext-install mysqli
 RUN pecl install xdebug-3.0.0
 RUN docker-php-ext-enable xdebug

--- a/php-80-cli-xdebug-30/Dockerfile
+++ b/php-80-cli-xdebug-30/Dockerfile
@@ -1,5 +1,4 @@
-FROM php:7.4
-# Install PECL extensions
+FROM php:8.0
 RUN docker-php-ext-install mysqli
 RUN pecl install xdebug-3.0.0
 RUN docker-php-ext-enable xdebug

--- a/php-80-cli-xdebug-30/Dockerfile
+++ b/php-80-cli-xdebug-30/Dockerfile
@@ -1,4 +1,4 @@
 FROM php:8.0
 RUN docker-php-ext-install mysqli
-RUN pecl install xdebug-3.0.0
+RUN pecl install xdebug-3.0.1
 RUN docker-php-ext-enable xdebug


### PR DESCRIPTION
As per title, I added some missing images so that all PHP versions from `7.2` onwards have Xdebug `2.9.8` and then I added all images with Xdebug `3.0` as well